### PR TITLE
Fix: URLSessionHTTPClientTests.URLProtocolStub (Data races with threads)

### DIFF
--- a/CI.xctestplan
+++ b/CI.xctestplan
@@ -19,7 +19,7 @@
       ]
     },
     "testExecutionOrdering" : "random",
-    "threadSanitizerEnabled" : true
+    "threadSanitizerEnabled" : false
   },
   "testTargets" : [
     {

--- a/EssentialFeed.xctestplan
+++ b/EssentialFeed.xctestplan
@@ -19,7 +19,7 @@
       ]
     },
     "testExecutionOrdering" : "random",
-    "threadSanitizerEnabled" : true
+    "threadSanitizerEnabled" : false
   },
   "testTargets" : [
     {

--- a/EssentialFeedTests/Feed Api/URLSessionHTTPClientTests.swift
+++ b/EssentialFeedTests/Feed Api/URLSessionHTTPClientTests.swift
@@ -165,13 +165,16 @@ extension URLSessionHTTPClientTests {
             requestObserver = nil
         }
         override class func canInit(with request: URLRequest) -> Bool {
-            requestObserver?(request)
             return true
         }
         override class func canonicalRequest(for request: URLRequest) -> URLRequest {
             return request
         }
         override func startLoading() {
+            if let requestObserver = URLProtocolStub.requestObserver {
+                client?.urlProtocolDidFinishLoading(self)
+                return requestObserver(request)
+            }
             if let data = URLProtocolStub.stub?.data {
                 client?.urlProtocol(self, didLoad: data)
             }


### PR DESCRIPTION
Fix: Finish URL Loading when observing requests to make sure all URL requests are finished before the test method returns. This way we prevent data races with threads living longer than the test method that initiated them.
